### PR TITLE
부서 순서 업데이트 로직 개선

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -12734,28 +12734,26 @@ let OrganizationManagementContextService = class OrganizationManagementContextSe
         const minOrder = Math.min(currentOrder, newOrder);
         const maxOrder = Math.max(currentOrder, newOrder);
         const affectedDepartments = await this.부서서비스.findDepartmentsInOrderRange(parentDepartmentId, minOrder, maxOrder);
+        await this.부서서비스.updateDepartment(departmentId, { order: -999 });
         const updates = [];
         if (currentOrder < newOrder) {
             for (const dept of affectedDepartments) {
-                if (dept.id === departmentId) {
-                    updates.push({ id: dept.id, order: newOrder });
-                }
-                else if (dept.order > currentOrder && dept.order <= newOrder) {
+                if (dept.id !== departmentId && dept.order > currentOrder && dept.order <= newOrder) {
                     updates.push({ id: dept.id, order: dept.order - 1 });
                 }
             }
         }
         else {
             for (const dept of affectedDepartments) {
-                if (dept.id === departmentId) {
-                    updates.push({ id: dept.id, order: newOrder });
-                }
-                else if (dept.order >= newOrder && dept.order < currentOrder) {
+                if (dept.id !== departmentId && dept.order >= newOrder && dept.order < currentOrder) {
                     updates.push({ id: dept.id, order: dept.order + 1 });
                 }
             }
         }
-        await this.부서서비스.bulkUpdateOrders(updates);
+        if (updates.length > 0) {
+            await this.부서서비스.bulkUpdateOrders(updates);
+        }
+        await this.부서서비스.updateDepartment(departmentId, { order: newOrder });
         return await this.부서서비스.findById(departmentId);
     }
     async 직책을_생성한다(직책정보) {


### PR DESCRIPTION
- 부서 이동 시 순서 업데이트를 위한 임시 음수 값 설정 로직을 추가하여 unique 제약 충돌을 회피하도록 수정하였습니다.
- 부서 순서 업데이트를 보다 명확하게 단계별로 처리하도록 리팩토링하였습니다.
- 업데이트가 필요한 부서 목록이 있을 경우에만 일괄 업데이트를 실행하도록 변경하였습니다.